### PR TITLE
[codex] Address CRAN resubmission notes

### DIFF
--- a/R/bugs.R
+++ b/R/bugs.R
@@ -102,7 +102,7 @@ check_and_map_color <- function(x) {
   } else
     stop("Invalid color specification.", call. = FALSE)
   
-  structure(x, .Names=c("r", "g", "b", "a"))
+  structure(x, names = c("r", "g", "b", "a"))
   
 }
 

--- a/README.md
+++ b/README.md
@@ -237,9 +237,6 @@ plot(g)
 
 ![Les Misérables network rendered with gexf-js](man/figures/lesmiserables.png)
 
-A live version of the figure is available
-[here](https://gvegayon.github.io/rgexf/lesmiserables/).
-
 ## Example 2: Static net
 
 ``` r

--- a/README.qmd
+++ b/README.qmd
@@ -101,8 +101,6 @@ plot(g)
 ```
 ![Les Misérables network rendered with gexf-js](man/figures/lesmiserables.png)
 
-A live version of the figure is available [here](https://gvegayon.github.io/rgexf/lesmiserables/).
-
 ## Example 2: Static net ##
 ```{r}
 # Creating a group of individuals and their relations
@@ -176,5 +174,4 @@ please go by creating a new issue
 about it.
 
 Please note that the rgexf project is released with a [Contributor Code of Conduct](https://contributor-covenant.org/version/2/0/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms
-
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -4,6 +4,15 @@ This is a resubmission of rgexf. The package was archived on CRAN on
 2026-05-18 because outstanding check issues were not corrected in time.
 This version (0.17.0) fixes those issues.
 
+The current resubmission feedback has also been addressed:
+
+* Deprecated `.Names` arguments in package code and `inst/CITATION` were
+  replaced with `names`.
+* The unavailable Les Misérables demo URL was removed from the README and
+  vignette.
+* `GEXF` is the acronym for Graph Exchange XML Format and `rgexf` is the
+  package name; both are included in `inst/WORDLIST`.
+
 The package contains no compiled (C/C++) code; all functionality is
 implemented in base R.
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -21,7 +21,7 @@ bibentry(bibtype = "Manual",
          title = "{{netdiffuseR: Build, Import and Export GEXF Graph Files}}",
          author = c(
           person("George", "Vega Yon", email="g.vegayon@gmail.com", role=c("aut", "cre"),
-            comment = structure("0000-0002-3171-0844", .Names = "ORCID")),
+            comment = structure("0000-0002-3171-0844", names = "ORCID")),
           person("Jorge", "Fábrega Lacoa", role=c("ctb")),
           person("Joshua", "Kunst", role=c("ctb"))
           ),
@@ -30,4 +30,3 @@ bibentry(bibtype = "Manual",
          url = "https://github.com/gvegayon/rgexf",
          doi = "10.5281/zenodo.5182708", 
          header = "And the actual R package:")
-

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -42,6 +42,7 @@ px
 rsdaphv
 rescaled
 rescales
+rgexf
 RGBA
 roxygen
 RXML
@@ -60,4 +61,3 @@ www
 xmlschema
 XSD
 yyyy
-

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -74,7 +74,7 @@ plot_gexfjs(g)
 knitr::include_graphics("lesmiserables.png")
 ```
 
-An live version of the figure is available [here](https://gvegayon.github.io/rgexf/lesmiserables/). Starting version 0.17.0, the default plot method uses `sigmajs` instead of `gexf-js`. Nonetheless, `gexf-js` is still available and can be embedded in quarto/rmarkdown documents: the last code chunk in this vignette shows how to do it.
+Starting with version 0.17.0, the default plot method uses `sigmajs` instead of `gexf-js`. Nonetheless, `gexf-js` is still available and can be embedded in Quarto/R Markdown documents: the last code chunk in this vignette shows how to do it.
 
 # Creating GEXF files
 


### PR DESCRIPTION
## Summary

This addresses the actionable feedback from the rgexf 0.17.0 CRAN resubmission. R-devel now reports deprecated uses of the special `.Names` argument, the README and built getting-started vignette linked to a Les Misérables demo endpoint that returns HTTP 404, and CRAN's incoming spell checker did not recognize the GEXF acronym or the rgexf package name.

The deprecated arguments produced NOTES in package code analysis and while reading `inst/CITATION`; leaving them in place would also make the package increasingly incompatible with future R releases. The dead link caused CRAN URL validation to fail and sent users to a missing page. The spelling findings are valid project-specific names rather than typos.

## Changes

- Replace `.Names` with `names` in `R/bugs.R` and `inst/CITATION`.
- Remove the unavailable Les Misérables demo link from the README source, rendered README, and getting-started vignette while retaining the bundled example image and current plotting guidance.
- Add `rgexf` to `inst/WORDLIST`; `GEXF` was already present.
- Document the fixes and proper-name explanation in `cran-comments.md` for the next submission.

## Validation

- Built a clean `rgexf_0.17.0.tar.gz` with `R CMD build` and verified that the generated `inst/doc/getting-started.html` has no dead demo URL.
- Ran `R CMD check --as-cran` on the clean tarball with R 4.5.1 on macOS: **0 errors, 0 warnings, 2 notes**.
  - The archive/new-submission NOTE is the expected CRAN repository record.
  - The other NOTE is local-only because macOS ships an obsolete HTML Tidy; CRAN's supplied Windows check validated the HTML manual successfully.
- Confirmed package code analysis no longer reports deprecated special names, the CITATION file is read successfully, tinytest passes, vignettes rebuild, and the PDF manual builds.
- Ran `devtools::spell_check()` and confirmed that `GEXF` and `rgexf` are no longer reported.
