### PR TITLE
Add pkgdown author profiles

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,3 +4,8 @@ destination: docs
 
 template:
   bootstrap: 5
+
+authors:
+  "George Vega Yon":
+    href: "https://ggvy.cl"
+    html: "<img src='https://ggvy.cl/img/george-g-vega-yon-university-of-utah.webp' width=72 alt=''>"

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -8,4 +8,3 @@ template:
 authors:
   "George Vega Yon":
     href: "https://ggvy.cl"
-    html: "<img src='https://ggvy.cl/img/george-g-vega-yon-university-of-utah.webp' width=72 alt=''>"


### PR DESCRIPTION
## Summary

- link George Vega Yon to https://ggvy.cl while preserving his displayed name
- add profile links for every package author listed in DESCRIPTION
- add a source pkgdown configuration where the published site did not already have one

## Validation

- loaded the package metadata with pkgdown
- verified exact author-name matching against DESCRIPTION
- verified every configured author mapping contains only an href attribute

Related to gvegayon/website#32.